### PR TITLE
Update test to reflect changes made in FCP Defra ID stub

### DIFF
--- a/test/features/example-grant-with-auth/sbi-driven-applications.feature
+++ b/test/features/example-grant-with-auth/sbi-driven-applications.feature
@@ -1,5 +1,6 @@
 Feature: Reusable grants-ui functionality
 
+    @ci
     Scenario: Begin a journey as an applicant, then continue and complete the journey as an agent with access to the same business
         Given there is no application state stored for SBI "119000002" and grant "example-grant-with-auth"
 

--- a/test/services/gas.js
+++ b/test/services/gas.js
@@ -21,7 +21,7 @@ class Gas {
           type: 'JSON',
           json: {
             metadata: {
-              sbi: sbi
+              sbi
             }
           }
         }

--- a/test/steps/given.js
+++ b/test/steps/given.js
@@ -25,7 +25,7 @@ Given('(the user )signs out of Defra ID', async () => {
 })
 
 Given('(the user )selects SBI {string}', async (sbi) => {
-  await $(`//div[contains(text(),'SBI: ${sbi}')]/preceding-sibling::input[@type='radio']`).click()
+  await $(`//div[contains(text(),'SBI ${sbi}')]/preceding-sibling::input[@type='radio']`).click()
 })
 
 Given('(the user )starts a new browser session', async () => {


### PR DESCRIPTION
v0.38.0 of fcp defra id stub changed some of the content to match whats being used in defra ID as a result of the changes, the tests in this repo now fail. More specifically the changes to the SBI picker of the service (CRN that belong to multiple SBI).

See:
https://github.com/DEFRA/fcp-defra-id-stub/commit/5f58eb658368b043752b9d357fe95baa979893cd#diff-5be2dcbb195eab8198e144497d82f0f39f92df232b7e318770c91d92e3bc7c54R34

Once this is merged, the tests in CDP portal will break until we merge https://github.com/DEFRA/grants-ui/pull/552.

https://github.com/DEFRA/grants-ui/pull/552 is blocked until we merge this PR