### PR TITLE
Ignore the failing spec until fcp defra id stub has been updated

### DIFF
--- a/test/features/example-grant-with-auth/sbi-driven-applications.feature
+++ b/test/features/example-grant-with-auth/sbi-driven-applications.feature
@@ -1,6 +1,5 @@
 Feature: Reusable grants-ui functionality
 
-    @ci
     Scenario: Begin a journey as an applicant, then continue and complete the journey as an agent with access to the same business
         Given there is no application state stored for SBI "119000002" and grant "example-grant-with-auth"
 


### PR DESCRIPTION
The radio button html has changed in v0.38.0 of defra id stub and we want to temporarily ignore the feature from CI while we update it

For context https://github.com/DEFRA/grants-ui-acceptance-tests/pull/7/changes#diff-52a5355c5516f5df21b8a489b3f1f46733d6af68841ac382f5d8e94bcf6c63e4L33 is where it fails as the radio button markup has changed